### PR TITLE
Fix misspellings across docs/

### DIFF
--- a/docs/dashboard/install-guide/common/oath2-support.md
+++ b/docs/dashboard/install-guide/common/oath2-support.md
@@ -16,7 +16,7 @@ spring.security.oauth2.client.registration.github.iconClass=fab fa-github
 ```
 Excluding either one of the Google or GitHub configuration sections will prevent the respective OAuth login button from being added to the Login page. 
 
-Note: To disable username/password authentication entirely and *only* supprt OAuth based authentication, set the following configuration property:
+Note: To disable username/password authentication entirely and *only* support OAuth based authentication, set the following configuration property:
 ```properties
 skills.authorization.oAuthOnly=true
 ```

--- a/docs/dashboard/install-guide/common/prod-install-basic-config.md
+++ b/docs/dashboard/install-guide/common/prod-install-basic-config.md
@@ -8,7 +8,7 @@ spring.datasource.url=jdbc:postgresql://<server>:5432/skills
 spring.datasource.username=
 spring.datasource.password=
 ```
-Please visit the [Database](/skills-docs/dashboard/install-guide/database.html) section for further inforamtion
+Please visit the [Database](/skills-docs/dashboard/install-guide/database.html) section for further information
             
 WebSocket Stomp:
 ```properties

--- a/docs/dashboard/user-guide/contact-admins.md
+++ b/docs/dashboard/user-guide/contact-admins.md
@@ -10,7 +10,7 @@ of SkillTree
 ![SkillTree Issues](../../screenshots/admin/page-contact_proj_admins.png) 
 
 Once a Root user has crafted an email, the content of the email can be be previewed using the ````Preview```` button which
-will send the specied email to the currently authenticated user to preview the content/formatting/display. Once satifisfied,
+will send the specified email to the currently authenticated user to preview the content/formatting/display. Once satisfied,
 pressing the ```Email``` button will send the specified email to all users of this instance of SkillTree who have the Project Administrator
 role.
 

--- a/docs/dashboard/user-guide/skills-groups.md
+++ b/docs/dashboard/user-guide/skills-groups.md
@@ -53,7 +53,7 @@ In this case, when any ``3`` skills under that group are completed then the grou
 
 Please note that in order to modify the number of required skills in a group, the ``Point Increment`` and ``Point Occurrences`` attributes must match for all the skills under that group. 
 If ``Point Increment`` and ``Point Occurrences`` are not aligned then the SkillTree dashboard will present a sync dialog to seamlessly align these attributes. 
-The reason for this requirement is that the group's skills points contribute to the subject's and project's points and when partial completio nis configured
+The reason for this requirement is that the group's skills points contribute to the subject's and project's points and when partial completion is configured
 there would be no consistent way to calculate points if they didn't align between the skills in that group.   
 
 ::: tip Partial Requirement Example

--- a/docs/release-notes/skills-service.md
+++ b/docs/release-notes/skills-service.md
@@ -55,7 +55,7 @@ To obtain deployable artifacts please visit [Distributions](/dashboard/install-g
 
 #### 1.7.0  
 <release-date date="Sep. 2021" />
-- Implemented store and display of aporoval history for self-report skills
+- Implemented store and display of approval history for self-report skills
 - Added ``Badges`` display for ``Progress and Ranking`` views
   - shows all global badges and project badges within the customized ``My Projects`` 
   - displays earned and available badges as well as current badge progress

--- a/docs/skills-client/README.md
+++ b/docs/skills-client/README.md
@@ -94,7 +94,7 @@ When reporting skill events you have 2 options:
 ![Skills Platform Report Skill Events Image](./diagrams/Integration-Reporter.jpg)
 
 ::: tip
-Generally option 1 is the most common use-case but sometimes it's easier to derive skill events on the backned server.  
+Generally option 1 is the most common use-case but sometimes it's easier to derive skill events on the backend server.  
 :::
 
 Please visit the following sections to learn more:

--- a/docs/skills-client/angular.md
+++ b/docs/skills-client/angular.md
@@ -70,7 +70,7 @@ the SkillsDisplay component:
 
 #### Route changed event <since project="skills-client" version="3.3.0" />
 
-Each time a user navigates within the Skills Client Display, the `handleRouteChanged` event is emitted containing the new path that was navigated to.  This can be useful if the hosting application displays a breadcumb and would like to update the current location within the Skills Client Display component.
+Each time a user navigates within the Skills Client Display, the `handleRouteChanged` event is emitted containing the new path that was navigated to.  This can be useful if the hosting application displays a breadcrumb and would like to update the current location within the Skills Client Display component.
 
 ``` js{7,14-16}
 import { Component } from '@angular/core';
@@ -94,7 +94,7 @@ export class ShowSkillsComponent {
 
 #### Programmatic navigation <since project="skills-client" version="3.3.1" />
 
-The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
+The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcrumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
 
 ``` js{7,14-15,19-21}
 import { Component } from '@angular/core';

--- a/docs/skills-client/js.md
+++ b/docs/skills-client/js.md
@@ -132,7 +132,7 @@ const clientDisplay = new SkillsDisplayJS({
 
 #### Route changed event <since project="skills-client" version="3.3.0" />
 
-Each time a user navigates within the Skills Client Display, if configured, the `handleRouteChanged` callback function will be invoked and passed the new path that was navigated to.  This can be useful if the hosting application displays a breadcumb and would like to update the current location within the Skills Client Display component.
+Each time a user navigates within the Skills Client Display, if configured, the `handleRouteChanged` callback function will be invoked and passed the new path that was navigated to.  This can be useful if the hosting application displays a breadcrumb and would like to update the current location within the Skills Client Display component.
 
 ``` js
 const handleRouteChanged = (newPath) => {
@@ -146,7 +146,7 @@ const clientDisplay = new SkillsDisplayJS({
 
 #### Programmatic navigation <since project="skills-client" version="3.3.1" />
 
-The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
+The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcrumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
 
 ``` js
   <button type="button" onclick="navigate()">Navigate</button>

--- a/docs/skills-client/react.md
+++ b/docs/skills-client/react.md
@@ -57,7 +57,7 @@ SkillsDisplay component properties:
 
 #### Route changed event <since project="skills-client" version="3.3.0" />
 
-Each time a user navigates within the Skills Client Display, if configured, the `handleRouteChanged` callback function will be invoked and passed the new path that was navigated to.  This can be useful if the hosting application displays a breadcumb and would like to update the current location within the Skills Client Display component.
+Each time a user navigates within the Skills Client Display, if configured, the `handleRouteChanged` callback function will be invoked and passed the new path that was navigated to.  This can be useful if the hosting application displays a breadcrumb and would like to update the current location within the Skills Client Display component.
 
 ``` js
 const handleRouteChanged = (newPath) => {
@@ -69,7 +69,7 @@ const handleRouteChanged = (newPath) => {
 
 #### Programmatic navigation <since project="skills-client" version="3.3.1" />
 
-The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
+The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcrumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
 
 ``` js
   const skillsDisplayRef = React.createRef()

--- a/docs/skills-client/vuejs.md
+++ b/docs/skills-client/vuejs.md
@@ -57,7 +57,7 @@ the SkillsDisplay component:
 
 #### Route changed event <since project="skills-client" version="3.3.0" />
 
-Each time a user navigates within the Skills Client Display, the `route-changed` event is emitted containing the new path that was navigated to.  This can be useful if the hosting application displays a breadcumb and would like to update the current location within the Skills Client Display component.
+Each time a user navigates within the Skills Client Display, the `route-changed` event is emitted containing the new path that was navigated to.  This can be useful if the hosting application displays a breadcrumb and would like to update the current location within the Skills Client Display component.
 
 ``` js{3,14-16}
 <template>
@@ -84,7 +84,7 @@ Each time a user navigates within the Skills Client Display, the `route-changed`
 
 #### Programmatic navigation <since project="skills-client" version="3.3.1" />
 
-The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
+The internal route of the Skills Client Display component can be changed by passing the desired path to the `navigate()` method.  This can be useful if the hosting application displays a breadcrumb and would like to navigate to different locations within the Skills Client Display component by clicking a breadcrumb link for example.
 
 ``` js{3-4,15-17}
 <template>


### PR DESCRIPTION
## Summary
Fix several instances of misspellings across docs/ with `.md` files.

## Files and Fixes
`supprt` -> `support`
`inforamtion` -> `information`
`satifisfied` -> `satisfied`
`completio nis` -> `completion is`
`aporoval` -> `approval`
`backned` -> `backend`
`breadcumb` -> `breadcrumb` (x8)